### PR TITLE
Notify user if patch is not installed on their system

### DIFF
--- a/nativecookie.nim
+++ b/nativecookie.nim
@@ -30,10 +30,16 @@ proc findElectron(): string =
 
 proc setup(): void =
     log("Setup")
-    log("Patch icon")
-    if 0 != execShellCmd("patch -f --binary -i \"" & nativeCookieDir /
+    log("Check if patch is installed on system")
+    if 0 != execShellCmd("patch"):
+        log("patch is not available on system, sending notification to user")
+        if 0 != execShellCmd("notify-send -a NativeCookie -u normal \"Could not patch the Cookie Clicker window icon because the patch utility is not installed on your system.\""):
+            log("Could not notify user of missing patch due to missing notify-send")
+    else:
+        log("Patch icon")
+        if 0 != execShellCmd("patch -f --binary -i \"" & nativeCookieDir /
             "icon_patch.diff" & "\" \"" & path / "resources/app/start.js" & "\""):
-        log("Failed!")
+            log("Failed!")
     if fileExists(nativeCookieDir / "greenworks/libsteam_api.so"):
         log("Installing greenworks binaries")
         copyFile(nativeCookieDir / "greenworks/greenworks-linux64.node", path / "resources/app/greenworks/lib/greenworks-linux64.node",)

--- a/nativecookie.nim
+++ b/nativecookie.nim
@@ -33,8 +33,8 @@ proc setup(): void =
     log("Check if patch is installed on system")
     if 0 != execShellCmd("patch"):
         log("patch is not available on system, sending notification to user")
-        if 0 != execShellCmd("notify-send -a NativeCookie -u normal \"Could not patch the Cookie Clicker window icon because the patch utility is not installed on your system.\""):
-            log("Could not notify user of missing patch due to missing notify-send")
+        if 0 != execShellCmd("zenity --title=\"NativeCookie\" --warning --text=\"Could not patch the Cookie Clicker window icon because the patch utility is not installed on your system. Please install it, then delete the 'nativeCookieVer' file from the Cookie Clicker game files and try again.\""):
+            log("Could not notify user of missing patch due to missing zenity")
     else:
         log("Patch icon")
         if 0 != execShellCmd("patch -f --binary -i \"" & nativeCookieDir /


### PR DESCRIPTION
Hi! I noticed that the window icon for Cookie Clicker was the default X window icon while using this, so I decided to investigate it a little. I found out that because my system did not have `patch` installed (I am using Fedora), it would not patch the start.js file, therefore resulting in the default X window icon. I have added a message box that tells the user to download patch, then to re-try setup if patch is missing from the system.
<img width="676" height="381" alt="Screenshot_20250808_110052" src="https://github.com/user-attachments/assets/25c4d1c1-7676-45ff-b2e4-0e948ecb6d14" />
