### PR TITLE
Lower glibc version requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,9 @@ jobs:
               curl -sL "https://web.archive.org/web/20250601110745/https://partner.steamgames.com/downloads/steamworks_sdk_161.zip" -o "steamworks.zip"
               unzip steamworks.zip -d deps/
               mv deps/sdk deps/steamworks_sdk
-          - run: npm install
+          - run: |
+              npm install
+              npm install -g node-gyp
           - run: HOME=~/.electron-gyp node-gyp rebuild --target=32.2.7 --arch=x64 --dist-url=https://electronjs.org/headers
           - uses: actions/upload-artifact@v6
             with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on: [push]
 
 jobs:
     Greenworks:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         defaults:
             run:
                 shell: bash
@@ -30,7 +30,7 @@ jobs:
               retention-days: 1
     Build:
         needs: Greenworks
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         defaults:
             run:
                 shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,26 @@ permissions:
 on: [push]
 
 jobs:
+    Greenworks:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                shell: bash
+        steps:
+          - uses: actions/checkout@v6
+            with:
+              repository: greenheartgames/greenworks
+          - run: |
+              mkdir deps/steamworks_sdk
+              curl -sL "https://web.archive.org/web/20250601110745/https://partner.steamgames.com/downloads/steamworks_sdk_161.zip" -o "steamworks.zip"
+              unzip -j steamworks.zip 'sdk/*' -d deps/steamworks_sdk
+          - run: npm install
+          - run: HOME=~/.electron-gyp node-gyp rebuild --target=32.2.7 --arch=x64 --dist-url=https://electronjs.org/headers
+          - uses: actions/upload-artifact@v6
+            with:
+              name: greenworks-bin
+              path: build/Release/greenworks-linux64.node
+              retention-days: 1
     Build:
         runs-on: ubuntu-latest
         defaults:
@@ -19,10 +39,13 @@ jobs:
             - run: rm */place*here
             - name: Download dependencies
               run: |
-                curl -sL "https://github.com/ElectronForConstruct/greenworks-prebuilds/releases/download/v0.8.0/greenworks-electron-v128-linux-x64.node" -o "greenworks/greenworks-linux64.node"
                 curl -sL "https://github.com/greenheartgames/greenworks/raw/refs/tags/v0.8.0/LICENSE" -o "LICENSE.greenworks"
                 curl -sL "https://github.com/electron/electron/releases/download/v32.2.7/electron-v32.2.7-linux-x64.zip" -o "electron/electron.zip"
                 curl -sL "https://web.archive.org/web/20250601110745/https://partner.steamgames.com/downloads/steamworks_sdk_161.zip" -o "steamworks.zip"
+            - uses: actions/download-artifact@v5
+              with:
+                name: greenworks-bin
+                path: greenworks/
             - name: Setup Steamworks
               run: |
                 unzip -j steamworks.zip sdk/redistributable_bin/linux64/libsteam_api.so sdk/public/steam/lib/linux64/libsdkencryptedappticket.so -d greenworks/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on: [push]
 
 jobs:
     Greenworks:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         defaults:
             run:
                 shell: bash
@@ -30,7 +30,7 @@ jobs:
               retention-days: 1
     Build:
         needs: Greenworks
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         defaults:
             run:
                 shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
             with:
               repository: greenheartgames/greenworks
           - run: |
-              mkdir deps/steamworks_sdk
               curl -sL "https://web.archive.org/web/20250601110745/https://partner.steamgames.com/downloads/steamworks_sdk_161.zip" -o "steamworks.zip"
-              unzip -j steamworks.zip 'sdk/*' -d deps/steamworks_sdk
+              unzip steamworks.zip -d deps/
+              mv deps/sdk deps/steamworks_sdk
           - run: npm install
           - run: HOME=~/.electron-gyp node-gyp rebuild --target=32.2.7 --arch=x64 --dist-url=https://electronjs.org/headers
           - uses: actions/upload-artifact@v6
@@ -27,6 +27,7 @@ jobs:
               path: build/Release/greenworks-linux64.node
               retention-days: 1
     Build:
+        needs: Greenworks
         runs-on: ubuntu-latest
         defaults:
             run:


### PR DESCRIPTION
This is done by...
a) building greenworks as part of the gh action instead of using a prebuild copy and
b) using an older version of Ubuntu as the runner image

Fixes #5