### PR TITLE
Run in steam linux runtime

### DIFF
--- a/toolmanifest.vdf
+++ b/toolmanifest.vdf
@@ -1,7 +1,7 @@
 "manifest"
 {
+  "version" "2"
+  "require_tool_appid" "1628350"
   "commandline" "/nativecookie run"
-  "commandline_waitforexitandrun" "/nativecookie run"
-  "commandline_getnativepath" "/nativecookie path"
-  "commandline_getcompatpath" "/nativecookie path"
+  "compatmanager_layer_name" "nativecookie"
 }


### PR DESCRIPTION
This makes it so NativeCookie runs in the SLR 3.0. This avoids the following error on NixOS:
 `/home/kesefon/.local/share/Steam/compatibilitytools.d/nativecookie/electron/cookie-electron: /home/kesefon/.local/share/Steam/ubuntu12_32/steam-runtime/usr/lib/x86_64-linux-gnu/libnss3.so: version 'NSS_3.30' not found (required by /home/kesefon/.local/share/Steam/compatibilitytools.d/nativecookie/electron/cookie-electron)
` 

- Not sure if there are any side effects. Needs more testing on more distros. 
  - Does this break on `steam-native`?
- Verbs other than `run` need to be implemented. (or do they? seems to work anyways)
- This might also solve #5 without relying on old CIs
  - Do I wanna build in SLR chroot?